### PR TITLE
Add initial location based auth methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+# Travis bug, see https://github.com/bundler/bundler/pull/3559
+before_install: gem update bundler
 rvm:
   - ruby-head
   - 2.1.1

--- a/README.md
+++ b/README.md
@@ -6,20 +6,23 @@ Creates objects with the following structure after parsing rightsMetadata XML
 ```ruby
 # Rights for an object or File
 class EntityRights
-  @world = #Rights
+  @world = Rights
   @group {
-    :stanford => #Rights
+    :stanford => Rights
   }
   @agent {
-    'app1' => #Rights,
-    'app2' => #Rights
+    'app1' => Rights,
+    'app2' => Rights
+  }
+  @location {
+    :spec => Rights
   }
 end
 
 # Rights for the entire object, and all files
 # This is the object used by apps (stacks and purl)
 class Dor::RightsAuth
-  @object_level = # EntityRights
+  @object_level = EntityRights
   @file {
     'file1' => EntityRights,
     'file2' => EntityRights

--- a/spec/rights_auth_spec.rb
+++ b/spec/rights_auth_spec.rb
@@ -326,6 +326,99 @@ describe Dor::RightsAuth do
 
   end
 
+  describe 'location based auth' do
+    let(:rights) { described_class.parse(rights_xml) }
+    context 'object level' do
+      let(:rights_xml) do
+        <<-XML
+          <rightsMetadata>
+            <access type="read">
+              <machine>
+                <location>spec</location>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns true if there is a matching location in the rights metadata' do
+        value, rule = rights.location_rights('spec')
+        expect(value).to be true
+        expect(rule).to be_nil
+      end
+
+      it 'returns false if there is no matching location in the rights metadata' do
+        value, rule = rights.location_rights('not-a-real-location')
+        expect(value).to be false
+        expect(rule).to be_nil
+      end
+
+      describe '#restricted_by_location?' do
+        it 'is true even when the given file has a no location restriction' do
+          expect(rights).to be_restricted_by_location('a-doc-that-is-not-there.doc')
+        end
+      end
+    end
+
+    context 'file level' do
+      let(:rights_xml) do
+        <<-XML
+          <rightsMetadata>
+            <access type="read">
+              <file>location-protected.doc</file>
+              <machine>
+                <location>spec</location>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns true if there is a matching location for the given file in the rights metadata' do
+        value, rule = rights.location_rights_for_file('location-protected.doc', 'spec')
+        expect(value).to be true
+        expect(rule).to be_nil
+      end
+
+      it 'returns false if there is no matching location for the given file in the rights metadata' do
+        value, rule = rights.location_rights_for_file('unkown.doc', 'spec')
+        expect(value).to be false
+        expect(rule).to be_nil
+      end
+
+      it 'returns false when there is a matching file but the location does not exist' do
+        value, rule = rights.location_rights_for_file('location-protected.doc', 'not-a-real-location')
+        expect(value).to be false
+        expect(rule).to be_nil
+      end
+
+      describe '#restricted_by_location?' do
+        it 'is true when the given file has a location restriction' do
+          expect(rights).to be_restricted_by_location('location-protected.doc')
+        end
+      end
+    end
+
+    context 'rules' do
+      let(:rights_xml) do
+        <<-XML
+          <rightsMetadata>
+            <access type="read">
+              <machine>
+                <location rule='no-download'>spec</location>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns the rule attribute as part of the rights' do
+        _, rule = rights.location_rights('spec')
+        expect(rule).to eq 'no-download'
+      end
+    end
+  end
+
   describe '#stanford_only_unrestricted_file?' do
 
     before(:all) do


### PR DESCRIPTION
Connects to #8 

I believe the current behavior would account for things requiring Stanford **OR** Location, but would not restrict location based content to **ONLY** Stanford users. (See #9)