### PR TITLE
add location and agent info to the Dor::RightsAuth#index_elements hash

### DIFF
--- a/spec/dor_services_examples_spec.rb
+++ b/spec/dor_services_examples_spec.rb
@@ -28,6 +28,6 @@ describe Dor::RightsAuth do
     r = Dor::RightsAuth.parse(xml, true)
     expect(r).to be_stanford_only_unrestricted
     expect(r).not_to be_public_unrestricted
-    expect(r.index_elements).to include :primary => 'stanford'
+    expect(r.index_elements).to include :primary => 'access_restricted'
   end
 end

--- a/spec/index_elements_spec.rb
+++ b/spec/index_elements_spec.rb
@@ -245,46 +245,46 @@ describe Dor::RightsAuth do
 
   describe 'multiple orthogonal rights types' do
     let(:rights) do
-    <<-EOXML
-    <objectType>
-      <rightsMetadata>
-        <access type="discover"><machine><world/></machine></access>    <!-- our most common "discover" -->
-        <access type="read">
-          <machine>
-            <world/>
-            <agent rule="objlevel">adminapp</agent>
-          </machine>
-        </access>
-        <access type="read">
-          <file>interview.doc</file>
-          <machine>
-            <group>stanford</group>
-            <world rule="no-download"/>
-            <agent>someapp1</agent>
-            <agent rule="somerule">someapp2</agent>
-            <location>reading_rm</location>
-          </machine>
-        </access>
-        <access type="read">
-          <file>other.doc</file>
-          <machine>
-            <group>other</group>
-            <group>stanford</group>
-            <world rule="no-download"/>
-            <location rule="new-rule">new_reading_rm</location>
-          </machine>
-        </access>
-        <access type="read">
-          <file>last.doc</file>
-          <machine>
-            <group rule="no-download">stanford</group>
-            <world rule="no-download"/>
-            <location rule="no-download">reading_rm</location>
-          </machine>
-        </access>
-      </rightsMetadata>
-    </objectType>
-    EOXML
+      <<-EOXML
+      <objectType>
+        <rightsMetadata>
+          <access type="discover"><machine><world/></machine></access>    <!-- our most common "discover" -->
+          <access type="read">
+            <machine>
+              <world/>
+              <agent rule="objlevel">adminapp</agent>
+            </machine>
+          </access>
+          <access type="read">
+            <file>interview.doc</file>
+            <machine>
+              <group>stanford</group>
+              <world rule="no-download"/>
+              <agent>someapp1</agent>
+              <agent rule="somerule">someapp2</agent>
+              <location>reading_rm</location>
+            </machine>
+          </access>
+          <access type="read">
+            <file>other.doc</file>
+            <machine>
+              <group>other</group>
+              <group>stanford</group>
+              <world rule="no-download"/>
+              <location rule="new-rule">new_reading_rm</location>
+            </machine>
+          </access>
+          <access type="read">
+            <file>last.doc</file>
+            <machine>
+              <group rule="no-download">stanford</group>
+              <world rule="no-download"/>
+              <location rule="no-download">reading_rm</location>
+            </machine>
+          </access>
+        </rightsMetadata>
+      </objectType>
+      EOXML
     end
     let(:r) { Dor::RightsAuth.parse(rights, true) }
     let(:i) { r.index_elements }

--- a/spec/index_elements_spec.rb
+++ b/spec/index_elements_spec.rb
@@ -163,7 +163,7 @@ describe Dor::RightsAuth do
       i = r.index_elements
       expect(i).to be
       expect(i[:errors] ).to be_empty
-      expect(i[:primary]).to eq 'stanford_qualified'
+      expect(i[:primary]).to eq 'access_restricted_qualified'
       expect(i[:terms]  ).to include('has_rule', 'has_group_rights', 'group|stanford_with_rule', 'world_discover')
       expect(i[:terms]  ).not_to include('world_read', 'none_read', 'none_discover')
     end

--- a/spec/index_elements_spec.rb
+++ b/spec/index_elements_spec.rb
@@ -256,6 +256,7 @@ describe Dor::RightsAuth do
             <world rule="no-download"/>
             <agent>someapp1</agent>
             <agent rule="somerule">someapp2</agent>
+            <location>reading_rm</location>
           </machine>
         </access>
         <access type="read">
@@ -264,13 +265,15 @@ describe Dor::RightsAuth do
             <group>other</group>
             <group>stanford</group>
             <world rule="no-download"/>
+            <location rule="new-rule">new_reading_rm</location>
           </machine>
         </access>
         <access type="read">
           <file>last.doc</file>
           <machine>
-            <group>stanford</group>
+            <group rule="no-download">stanford</group>
             <world rule="no-download"/>
+            <location rule="no-download">reading_rm</location>
           </machine>
         </access>
       </rightsMetadata>

--- a/spec/index_elements_spec.rb
+++ b/spec/index_elements_spec.rb
@@ -237,8 +237,9 @@ describe Dor::RightsAuth do
     end
   end
 
-  describe '#agent_rights' do
-    rights = <<-EOXML
+  describe 'multiple orthogonal rights types' do
+    let(:rights) do
+    <<-EOXML
     <objectType>
       <rightsMetadata>
         <access type="discover"><machine><world/></machine></access>    <!-- our most common "discover" -->
@@ -275,12 +276,18 @@ describe Dor::RightsAuth do
       </rightsMetadata>
     </objectType>
     EOXML
-    r = Dor::RightsAuth.parse(rights, true)
-    it 'handles agent rights at multiple levels' do
-      i = r.index_elements
+    end
+    let(:r) { Dor::RightsAuth.parse(rights, true) }
+    let(:i) { r.index_elements }
+
+    it 'exists and has no errors' do
       expect(i).to be
       expect(i[:errors] ).to be_empty
+    end
+    it 'has the expected primary value' do
       expect(i[:primary]).to eq 'world_qualified'
+    end
+    it 'has the expected terms' do
       [ 'world_read', 'world_discover', 'has_rule', 'has_file_rights',
         'file_has_group', 'file_has_world', 'file_has_agent',
         'file_rights_count|3', 'file_rights_for_agent|2',


### PR DESCRIPTION
* refactor a bit so that naming and organization are a bit more informative, to make it easier to add some new fields to the `index_elements` hash.
* capture location and agent info at the object and file level to add to the hash.
* fix primary rights determination to consider `location`, `agent`, and `group` (just `'stanford'` at the moment) access types to be of equal precedence.  comment about what primary rights represent.
* test cases for the new information, and a bit of supporting test data.

connected to #17