### PR TITLE
Update how we send test metrics to codeclimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - 2.3.1
   - 2.2.5
   - 2.1.2
+
+after_script:
+  - bundle exec codeclimate-test-reporter

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,12 +4,9 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'bundler/setup'
 require 'rspec'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
 require 'coveralls'
 Coveralls.wear!
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  CodeClimate::TestReporter::Formatter,
   Coveralls::SimpleCov::Formatter
 ]
 


### PR DESCRIPTION
The previous approach is deprecated and causes the test suite to fail.