### PR TITLE
get CODECLIMATE_REPO_TOKEN from repo secrets for coverage reporting

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    environment: CI
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,4 +24,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report CodeClimate
+      env:
+        CODECLIMATE_REPO_TOKEN: ${{ secrets.CODECLIMATE_REPO_TOKEN }}
       run: bundle exec codeclimate-test-reporter


### PR DESCRIPTION
## Why was this change made?

trying to get code climate reporting working to address this error message from the switch to GH actions:
<img width="1405" alt="Screen Shot 2021-01-04 at 6 10 15 PM" src="https://user-images.githubusercontent.com/7741604/103598711-2b292d80-4eb8-11eb-8a98-11b445183313.png">


## How was this change tested?

this PR 🤞 

## Which documentation and/or configurations were updated?

github actions CI workflow
